### PR TITLE
Painting workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "5.2.6",
         "@mdi/font": "7.4.47",
+        "@vueuse/core": "^14.1.0",
         "pinia": "^3.0.3",
         "pinia-plugin-persistedstate": "^4.7.1",
         "vue": "^3.5.17",
@@ -1577,6 +1578,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -2384,6 +2391,44 @@
       "peerDependencies": {
         "vue": "^3.0.0",
         "vuetify": "^3.0.0"
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.1.0.tgz",
+      "integrity": "sha512-rgBinKs07hAYyPF834mDTigH7BtPqvZ3Pryuzt1SD/lg5wEcWqvwzXXYGEDb2/cP0Sj5zSvHl3WkmMELr5kfWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.1.0",
+        "@vueuse/shared": "14.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.1.0.tgz",
+      "integrity": "sha512-7hK4g015rWn2PhKcZ99NyT+ZD9sbwm7SGvp7k+k+rKGWnLjS/oQozoIZzWfCewSUeBmnJkIb+CNr7Zc/EyRnnA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.1.0.tgz",
+      "integrity": "sha512-EcKxtYvn6gx1F8z9J5/rsg3+lTQnvOruQd8fUecW99DCK04BkWD7z5KQ/wTAx+DazyoEE9dJt/zV8OIEQbM6kw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@fontsource/roboto": "5.2.6",
     "@mdi/font": "7.4.47",
+    "@vueuse/core": "^14.1.0",
     "pinia": "^3.0.3",
     "pinia-plugin-persistedstate": "^4.7.1",
     "vue": "^3.5.17",

--- a/src/components/Map/MapGrid.vue
+++ b/src/components/Map/MapGrid.vue
@@ -1,18 +1,92 @@
 <template>
     <div class="map-container" :style="containerStyles">
         <div class="map-row" :style="rowStyles" v-for="row in mapStore.mapHeight">
-            <map-grid-cell v-for="col in mapStore.mapWidth" :row="row" :col="col"></map-grid-cell>
+            <map-grid-cell v-for="col in mapStore.mapWidth" 
+                :row="row" 
+                :col="col" 
+                :selection="cellSelectionRange"
+                :brush-mode="isInBrushMode"
+                @select-start="onSelectStart" 
+                @select-move="onSelectMove" 
+                @select-end="onSelectEnd"
+                @enter-brush-mode="onEnterBrushMode"
+                @exit-brush-mode="onExitBrushMode"></map-grid-cell>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
-    import { computed } from 'vue';
-    import { useMapStore } from '@/state/mapStore';
+    import { computed, ref } from 'vue';
+    import { onKeyStroke } from '@vueuse/core'
+    import { MAP_MODE, useMapStore } from '@/state/mapStore';
     import { useSpritesStore } from '@/state/spritesStore';
+    import { type cellPos } from '@/types';
 
     const mapStore = useMapStore();
     const spriteStore = useSpritesStore();
+
+    const isInBrushMode = ref(false);
+    const isSelecting = ref(false);
+    const selectionStart = ref<cellPos| null>(null);
+    const selectionEnd = ref<cellPos | null>(null);
+
+    const onSelectStart = (position: cellPos) => {
+        if (mapStore.editMode !== MAP_MODE.SELECT) return;
+        selectionStart.value = position;
+        selectionEnd.value = position;
+        isSelecting.value = true;
+    };
+
+    const onSelectMove = (position: cellPos) => {
+        if (mapStore.editMode !== MAP_MODE.SELECT) return;
+        if (!isSelecting.value) return;
+        selectionEnd.value = position;
+    };
+
+    const onSelectEnd = (position: cellPos) => {
+        if (mapStore.editMode !== MAP_MODE.SELECT) return;
+        isSelecting.value = false;
+        selectionEnd.value = position;
+    };
+
+    const onEnterBrushMode = () => {
+        isInBrushMode.value = true;
+    };
+
+    const onExitBrushMode = () => {
+        isInBrushMode.value = false;
+    };
+
+    const deselect = () => {
+        selectionStart.value = null;
+        selectionEnd.value = null;
+    };
+
+    const fillSelection = () => {
+        if (!spriteStore.selectedSpriteID) return;
+
+        const [sheetId, spriteId] = spriteStore.selectedSpriteID;
+        mapStore.fillTileSpriteRange(cellSelectionRange.value!.start, cellSelectionRange.value!.end, sheetId, spriteId);
+        deselect();
+    };
+
+    const clearSelection = () => {
+        mapStore.clearTileSpriteRange(cellSelectionRange.value!.start, cellSelectionRange.value!.end);
+        deselect();
+        deselect();
+    };
+
+    onKeyStroke('Escape', (e) => {
+       deselect();
+    });
+
+    onKeyStroke('f', (e) => {
+       fillSelection();
+    });
+
+    onKeyStroke('x', (e) => {
+       clearSelection();
+    });
 
     const containerStyles = computed(() => {
         const mapWidth = (mapStore.mapWidth * mapStore.cellDisplaySize) + "px";
@@ -33,6 +107,18 @@
             '--cell-size': mapStore.cellDisplaySize + "px",
             ...sheetVars
         }
+    });
+
+    const cellSelectionRange = computed(() => {
+        if (selectionStart.value == null || selectionEnd == null) {
+            return null;
+        }
+
+        const startRow = Math.min(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
+        const endRow = Math.max(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
+        const startCol = Math.min(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
+        const endCol = Math.max(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
+        return { start: { row: startRow, col: startCol }, end: { row: endRow, col: endCol } };
     });
 
     const rowStyles = computed(() => {

--- a/src/components/Map/MapGrid.vue
+++ b/src/components/Map/MapGrid.vue
@@ -4,7 +4,7 @@
             <map-grid-cell v-for="col in mapStore.mapWidth" 
                 :row="row" 
                 :col="col" 
-                :selection="cellSelectionRange"
+                :selection="mapStore.cellSelectionRange"
                 :brush-mode="isInBrushMode"
                 @select-start="onSelectStart" 
                 @select-move="onSelectMove" 
@@ -17,7 +17,6 @@
 
 <script setup lang="ts">
     import { computed, ref } from 'vue';
-    import { onKeyStroke } from '@vueuse/core'
     import { MAP_MODE, useMapStore } from '@/state/mapStore';
     import { useSpritesStore } from '@/state/spritesStore';
     import { type cellPos } from '@/types';
@@ -27,26 +26,24 @@
 
     const isInBrushMode = ref(false);
     const isSelecting = ref(false);
-    const selectionStart = ref<cellPos| null>(null);
-    const selectionEnd = ref<cellPos | null>(null);
 
     const onSelectStart = (position: cellPos) => {
         if (mapStore.editMode !== MAP_MODE.SELECT) return;
-        selectionStart.value = position;
-        selectionEnd.value = position;
+        mapStore.selectionStart = position;
+        mapStore.selectionEnd = position;
         isSelecting.value = true;
     };
 
     const onSelectMove = (position: cellPos) => {
         if (mapStore.editMode !== MAP_MODE.SELECT) return;
         if (!isSelecting.value) return;
-        selectionEnd.value = position;
+        mapStore.selectionEnd = position;
     };
 
     const onSelectEnd = (position: cellPos) => {
         if (mapStore.editMode !== MAP_MODE.SELECT) return;
         isSelecting.value = false;
-        selectionEnd.value = position;
+        mapStore.selectionEnd = position;
     };
 
     const onEnterBrushMode = () => {
@@ -56,37 +53,6 @@
     const onExitBrushMode = () => {
         isInBrushMode.value = false;
     };
-
-    const deselect = () => {
-        selectionStart.value = null;
-        selectionEnd.value = null;
-    };
-
-    const fillSelection = () => {
-        if (!spriteStore.selectedSpriteID) return;
-
-        const [sheetId, spriteId] = spriteStore.selectedSpriteID;
-        mapStore.fillTileSpriteRange(cellSelectionRange.value!.start, cellSelectionRange.value!.end, sheetId, spriteId);
-        deselect();
-    };
-
-    const clearSelection = () => {
-        mapStore.clearTileSpriteRange(cellSelectionRange.value!.start, cellSelectionRange.value!.end);
-        deselect();
-        deselect();
-    };
-
-    onKeyStroke('Escape', (e) => {
-       deselect();
-    });
-
-    onKeyStroke('f', (e) => {
-       fillSelection();
-    });
-
-    onKeyStroke('x', (e) => {
-       clearSelection();
-    });
 
     const containerStyles = computed(() => {
         const mapWidth = (mapStore.mapWidth * mapStore.cellDisplaySize) + "px";
@@ -107,18 +73,6 @@
             '--cell-size': mapStore.cellDisplaySize + "px",
             ...sheetVars
         }
-    });
-
-    const cellSelectionRange = computed(() => {
-        if (selectionStart.value == null || selectionEnd == null) {
-            return null;
-        }
-
-        const startRow = Math.min(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
-        const endRow = Math.max(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
-        const startCol = Math.min(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
-        const endCol = Math.max(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
-        return { start: { row: startRow, col: startCol }, end: { row: endRow, col: endCol } };
     });
 
     const rowStyles = computed(() => {

--- a/src/components/Map/MapGridCell.vue
+++ b/src/components/Map/MapGridCell.vue
@@ -25,6 +25,9 @@ const cellClickAction = () => {
     if (mapStore.editMode == MAP_MODE.PAINT) {
         paintCell();
     }
+    else if (mapStore.editMode == MAP_MODE.SAMPLE) {
+        sampleCell();
+    }
     else if (mapStore.editMode == MAP_MODE.ERASE) {
         clearCell();
     }
@@ -74,6 +77,13 @@ const paintCell = () => {
     if (spriteStore.selectedSpriteID) {
         let [sheetId, spriteId] = spriteStore.selectedSpriteID;
         mapStore.setTileSprite(props.row, props.col, sheetId, spriteId);
+    }
+};
+
+const sampleCell = () => {
+    const cell = mapStore.getCell(props.row, props.col);
+    if (cell.sprite != null) {
+        spriteStore.setSelectedSprite(cell.sprite[0], cell.sprite[1]);
     }
 };
 

--- a/src/components/Map/MapGridCell.vue
+++ b/src/components/Map/MapGridCell.vue
@@ -22,17 +22,11 @@ const mapStore = useMapStore();
 const spriteStore = useSpritesStore();
 
 const cellClickAction = () => {
-    switch(mapStore.editMode) {
-        case MAP_MODE.PAINT:
-            paintCell();
-            break;
-        case MAP_MODE.FILL:
-            break;
-        case MAP_MODE.ERASE:
-            clearCell();
-            break;
-        default:
-            // Cell Select Action
+    if (mapStore.editMode == MAP_MODE.PAINT) {
+        paintCell();
+    }
+    else if (mapStore.editMode == MAP_MODE.ERASE) {
+        clearCell();
     }
 };
 

--- a/src/components/Map/MapGridCell.vue
+++ b/src/components/Map/MapGridCell.vue
@@ -1,8 +1,13 @@
 <template>
     <div class="map-grid-cell"
-        :class="mapStore.enableGrid ? 'gridded' : ''"
+        :class="cellClasses"
         :style="cellStyles"
-        @click="cellClickAction">
+        @click="cellClickAction"
+        @mousedown="mouseDownAction"
+        @mouseover="mouseOverAction"
+        @mouseup="mouseUpAction"
+        @mouseenter="mouseEnterEffect"
+        >
     </div>
 </template>
 
@@ -11,28 +16,75 @@ import { MAP_MODE, useMapStore } from '@/state/mapStore';
 import { useSpritesStore } from '@/state/spritesStore';
 import { computed } from 'vue';
 
-const props = defineProps(['cellindex', 'row', 'col']);
+const props = defineProps(['cellindex', 'row', 'col', 'selection', 'brushMode']);
+const emits = defineEmits(['selectStart', 'selectMove', 'selectEnd', 'enterBrushMode', 'exitBrushMode']);
 const mapStore = useMapStore();
 const spriteStore = useSpritesStore();
 
 const cellClickAction = () => {
     switch(mapStore.editMode) {
         case MAP_MODE.PAINT:
-            // cell fill action
-            if (spriteStore.selectedSpriteID) {
-                let [sheetId, spriteId] = spriteStore.selectedSpriteID;
-                mapStore.setTileSprite(props.row, props.col, sheetId, spriteId);
-            }
+            paintCell();
             break;
         case MAP_MODE.FILL:
             break;
         case MAP_MODE.ERASE:
-                mapStore.clearTileSprite(props.row, props.col);
+            clearCell();
             break;
         default:
             // Cell Select Action
     }
+};
 
+const mouseDownAction = () => {
+    if (mapStore.editMode == MAP_MODE.SELECT) {
+        emits("selectStart", {row: props.row, col: props.col});
+    }
+    else if (mapStore.editMode == MAP_MODE.PAINT) {
+        emits("enterBrushMode");
+        paintCell();
+    }
+    else if (mapStore.editMode == MAP_MODE.ERASE) {
+        emits("enterBrushMode");
+        clearCell();
+    }  
+};
+
+const mouseOverAction = () => {
+    if (mapStore.editMode == MAP_MODE.SELECT) {
+        emits("selectMove", {row: props.row, col: props.col});
+    }
+    
+};
+
+const mouseUpAction = () => {
+    if (mapStore.editMode == MAP_MODE.SELECT) {
+        emits("selectEnd", {row: props.row, col: props.col});
+    }
+    else if (mapStore.editMode == MAP_MODE.PAINT) {
+        emits("exitBrushMode");
+    }
+    else if (mapStore.editMode == MAP_MODE.ERASE) {
+        emits("exitBrushMode");
+    }
+};
+
+const mouseEnterEffect = () => {
+    if (!props.brushMode) return;
+    if (mapStore.editMode == MAP_MODE.PAINT) paintCell();
+    else if (mapStore.editMode == MAP_MODE.ERASE) clearCell();
+};
+
+
+const paintCell = () => {
+    if (spriteStore.selectedSpriteID) {
+        let [sheetId, spriteId] = spriteStore.selectedSpriteID;
+        mapStore.setTileSprite(props.row, props.col, sheetId, spriteId);
+    }
+};
+
+const clearCell = () => {
+    mapStore.clearTileSprite(props.row, props.col);
 };
 
 const cellStyles = computed(() => {
@@ -52,6 +104,26 @@ const cellStyles = computed(() => {
 
     return bgStyles;
 });
+
+const isCellSelected = computed(() => {
+    if (props.selection == null ) {
+        return false;
+    }
+
+    return (props.row >= props.selection.start.row && props.row <= props.selection.end.row &&
+            props.col >= props.selection.start.col && props.col <= props.selection.end.col);
+});
+
+const cellClasses = computed(() => {
+    return {
+        'gridded': mapStore.enableGrid,
+        'selection-start-row': isCellSelected.value &&  props.row == props.selection.start.row,
+        'selection-end-row': isCellSelected.value &&  props.row == props.selection.end.row,
+        'selection-start-col': isCellSelected.value &&  props.col == props.selection.start.col,
+        'selection-end-col': isCellSelected.value &&  props.col == props.selection.end.col,
+    };
+});
+
 </script>
 
 
@@ -85,4 +157,30 @@ const cellStyles = computed(() => {
     .map-grid-cell:hover::before {
         border-color: rgba(var(--v-border-color), 0.8);
     }
+
+    .map-grid-cell.selection-start-row {
+        border-top-style: dashed;
+        border-top-color: white;
+        border-top-width: thin;
+    }
+
+    .map-grid-cell.selection-end-row {
+        border-bottom-style: dashed;
+        border-bottom-color: white;
+        border-bottom-width: thin;
+    }
+
+    .map-grid-cell.selection-start-col{
+        border-left-style: dashed;
+        border-left-color: white;
+        border-left-width: thin;
+    }
+
+    .map-grid-cell.selection-end-col{
+        border-right-style: dashed;
+        border-right-color: white;
+        border-right-width: thin;
+    }
+
+
 </style>

--- a/src/components/Map/MapModeSelector.vue
+++ b/src/components/Map/MapModeSelector.vue
@@ -12,9 +12,14 @@
                     <v-btn icon="mdi-cursor-default"  v-bind="props"></v-btn>
                 </template>
             </v-tooltip>
-            <v-tooltip text="Paint (w)" location="top">
+            <v-tooltip text="Brush (b)" location="top">
                 <template v-slot:activator="{ props }">
                     <v-btn icon="mdi-brush" v-bind="props"></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Eyedropper (I)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn icon="mdi-eyedropper" v-bind="props"></v-btn>
                 </template>
             </v-tooltip>
             <v-tooltip text="Erase (e)" location="top">
@@ -64,8 +69,11 @@
     onKeyStroke('s', () => {
        mapStore.editMode = MAP_MODE.SELECT;
     });
-    onKeyStroke('w', () => {
+    onKeyStroke('b', () => {
        mapStore.editMode = MAP_MODE.PAINT;
+    });
+    onKeyStroke('i', () => {
+       mapStore.editMode = MAP_MODE.SAMPLE;
     });
     onKeyStroke('e', () => {
        mapStore.editMode = MAP_MODE.ERASE;

--- a/src/components/Map/MapModeSelector.vue
+++ b/src/components/Map/MapModeSelector.vue
@@ -7,15 +7,77 @@
             rounded
             density="comfortable"
             variant="tonal" >
-            <v-btn icon="mdi-cursor-default"></v-btn>
-            <v-btn icon="mdi-brush"></v-btn>
-            <v-btn icon="mdi-format-color-fill"></v-btn>
-            <v-btn icon="mdi-eraser"></v-btn>
+            <v-tooltip text="Select (s)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn icon="mdi-cursor-default"  v-bind="props"></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Paint (w)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn icon="mdi-brush" v-bind="props"></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Erase (e)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn icon="mdi-eraser" v-bind="props"></v-btn>
+                </template>
+            </v-tooltip>
         </v-btn-toggle>
+        <v-btn-group
+            class="ml-4"
+            divided
+            rounded
+            density="comfortable"
+            variant="tonal">
+            <v-tooltip text="Fill Selection (f)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn @click="fillSelection" v-bind="props" icon="mdi-format-color-fill" :disabled="!mapStore.hasSelectionRange || !spriteStore.selectedSpriteID"></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Clear Selection (x)" location="top">
+                <template v-slot:activator="{ props }">
+                    <v-btn @click="clearSelection" v-bind="props" icon="mdi-water-remove"  :disabled="!mapStore.hasSelectionRange"></v-btn>
+                </template>
+            </v-tooltip>
+        </v-btn-group>
     </div>
 </template>
 
 <script setup lang="ts">
-    import { useMapStore } from '@/state/mapStore';
+    import { onKeyStroke } from '@vueuse/core'
+    import { MAP_MODE, useMapStore } from '@/state/mapStore';
+    import { useSpritesStore } from '@/state/spritesStore';
+
     const mapStore = useMapStore();
+    const spriteStore = useSpritesStore();
+
+    const fillSelection = () => {
+        if (!spriteStore.selectedSpriteID || !mapStore.hasSelectionRange) return;
+        const [sheetId, spriteId] = spriteStore.selectedSpriteID;
+        mapStore.fillSelectionWithSprite(sheetId, spriteId);
+    };
+
+    const clearSelection = () => {
+        mapStore.clearSpritesFromSelection();
+    };
+
+    onKeyStroke('s', () => {
+       mapStore.editMode = MAP_MODE.SELECT;
+    });
+    onKeyStroke('w', () => {
+       mapStore.editMode = MAP_MODE.PAINT;
+    });
+    onKeyStroke('e', () => {
+       mapStore.editMode = MAP_MODE.ERASE;
+    });
+    onKeyStroke('f', (e) => {
+        fillSelection();
+    });
+    onKeyStroke('x', (e) => {
+       clearSelection();
+    });
+    onKeyStroke('Escape', (e) => {
+       mapStore.clearSelectionRange();
+    });
+ 
 </script>

--- a/src/state/mapStore.ts
+++ b/src/state/mapStore.ts
@@ -4,7 +4,7 @@ import { computed, ref, reactive, watch, toRaw } from 'vue'
 
 const StoreName = "levelMap";
 
-export enum MAP_MODE {SELECT = 0, PAINT = 1, FILL = 2, ERASE = 3};
+export enum MAP_MODE {SELECT = 0, PAINT = 1, ERASE = 2};
 
 type mapCell = {
     sprite: [number, number] | null;
@@ -46,6 +46,9 @@ export const useMapStore = defineStore(StoreName, () => {
     const mapScale = ref<number>(DEFAULT_MAP_SCALE);
     const mapBackground = ref<string>(DEFAULT_MAP_BACKGROUND);
 
+    const selectionStart = ref<cellPos| null>(null);
+    const selectionEnd = ref<cellPos | null>(null);
+
     // This is used to trigger a persistance update after the deeply reactive mapGrid changes.
     // Watchers on mapWidth and mapHeight will toggle this value to force a save after the grid has been resized.
     const persistTrigger = ref<boolean>(false);
@@ -82,13 +85,20 @@ export const useMapStore = defineStore(StoreName, () => {
     const editMode = ref<MAP_MODE>(MAP_MODE.SELECT);
 
     // Watchers
-
+    
     watch(mapWidth, (newWidth, oldWidth) => {
         if (newWidth > oldWidth) {
             const diff = newWidth - oldWidth;
             for (let r = 0; r < mapHeight.value; r++) {
                 for (let c = 0; c < diff; c++) {
-                    mapGrid[r].push({sprite: null});
+                    if (!mapGrid[r]) {
+                        mapGrid[r] = [];
+                        for (let c = 0; c < newWidth; c++) {
+                            mapGrid[r].push({sprite: null});
+                        }
+                    } else {
+                        mapGrid[r].push({sprite: null});
+                    }
                 }
             }
         } else {
@@ -149,30 +159,58 @@ export const useMapStore = defineStore(StoreName, () => {
         return mapGrid[row][col];
     }
 
+    const hasSelectionRange = computed(() => {
+        return selectionStart.value != null && selectionEnd.value != null;
+    });
+
+    const cellSelectionRange = computed(() => {
+        if (selectionStart.value == null || selectionEnd == null) {
+            return null;
+        }
+
+        const startRow = Math.min(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
+        const endRow = Math.max(selectionStart.value?.row || 0, selectionEnd.value?.row || 0);
+        const startCol = Math.min(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
+        const endCol = Math.max(selectionStart.value?.col || 0, selectionEnd.value?.col || 0);
+        return { start: { row: startRow, col: startCol }, end: { row: endRow, col: endCol } };
+    });
+
     // Actions
 
     const setTileSprite = (row: number, col: number, sheetIndex: number, spriteIndex: number) => {
         getCell(row, col).sprite = [sheetIndex, spriteIndex];
     }
 
-    const fillTileSpriteRange = (startTile:cellPos, endTile: cellPos, sheetIndex: number, spriteIndex: number) => {
-        for (let r = startTile.row; r <= endTile.row; r++) {
-            for (let c = startTile.col; c <= endTile.col; c++) {
-                setTileSprite(r, c, sheetIndex, spriteIndex);
+    const fillSelectionWithSprite = (sheetId: number, spriteId: number) => {
+        if (!hasSelectionRange.value || sheetId < 0 || spriteId < 0) return;
+
+        for (let r = cellSelectionRange.value!.start.row; r <= cellSelectionRange.value!.end.row; r++) {
+            for (let c = cellSelectionRange.value!.start.col; c <= cellSelectionRange.value!.end.col; c++) {
+                setTileSprite(r, c, sheetId, spriteId);
             }
         }
-    }
+
+        clearSelectionRange();
+    };
 
     const clearTileSprite = (row: number, col: number) => {
         getCell(row, col).sprite = null;
     }
 
-    const clearTileSpriteRange = (startTile:cellPos, endTile: cellPos) => {
-        for (let r = startTile.row; r <= endTile.row; r++) {
-            for (let c = startTile.col; c <= endTile.col; c++) {
+    const clearSpritesFromSelection = () => {
+        if (!hasSelectionRange.value) return;
+
+         for (let r = cellSelectionRange.value!.start.row; r <= cellSelectionRange.value!.end.row; r++) {
+            for (let c = cellSelectionRange.value!.start.col; c <= cellSelectionRange.value!.end.col; c++) {
                 clearTileSprite(r, c);
             }
         }
+        clearSelectionRange();
+    };
+
+    const clearSelectionRange = () => {
+        selectionStart.value = null;
+        selectionEnd.value = null;
     }
 
 
@@ -182,6 +220,8 @@ export const useMapStore = defineStore(StoreName, () => {
         mapHeight,
         mapScale,
         mapBackground,
+        selectionStart,
+        selectionEnd,
         enableGrid,
         mapGrid,
         mapGridRef,
@@ -189,14 +229,18 @@ export const useMapStore = defineStore(StoreName, () => {
         editMode,
         getCell,
         getCellByIndex,
+        hasSelectionRange,
+        cellSelectionRange,
         setTileSprite,
-        fillTileSpriteRange,
+        fillSelectionWithSprite,
+        clearSpritesFromSelection,
         clearTileSprite,
-        clearTileSpriteRange,
+        clearSelectionRange,
     };
 
 }, {
     persist: {
-        serializer: serializer
+        serializer: serializer,
+        omit: ['selectionStart', 'selectionEnd'],
     },
 });

--- a/src/state/mapStore.ts
+++ b/src/state/mapStore.ts
@@ -1,12 +1,12 @@
+import type { cellPos } from '@/types';
 import { defineStore, type StateTree } from 'pinia'
-import type { Serializer } from 'pinia-plugin-persistedstate';
 import { computed, ref, reactive, watch, toRaw } from 'vue'
 
 const StoreName = "levelMap";
 
 export enum MAP_MODE {SELECT = 0, PAINT = 1, FILL = 2, ERASE = 3};
 
-export type mapCell = {
+type mapCell = {
     sprite: [number, number] | null;
 }
 
@@ -149,12 +149,30 @@ export const useMapStore = defineStore(StoreName, () => {
         return mapGrid[row][col];
     }
 
+    // Actions
+
     const setTileSprite = (row: number, col: number, sheetIndex: number, spriteIndex: number) => {
         getCell(row, col).sprite = [sheetIndex, spriteIndex];
     }
 
+    const fillTileSpriteRange = (startTile:cellPos, endTile: cellPos, sheetIndex: number, spriteIndex: number) => {
+        for (let r = startTile.row; r <= endTile.row; r++) {
+            for (let c = startTile.col; c <= endTile.col; c++) {
+                setTileSprite(r, c, sheetIndex, spriteIndex);
+            }
+        }
+    }
+
     const clearTileSprite = (row: number, col: number) => {
         getCell(row, col).sprite = null;
+    }
+
+    const clearTileSpriteRange = (startTile:cellPos, endTile: cellPos) => {
+        for (let r = startTile.row; r <= endTile.row; r++) {
+            for (let c = startTile.col; c <= endTile.col; c++) {
+                clearTileSprite(r, c);
+            }
+        }
     }
 
 
@@ -172,7 +190,9 @@ export const useMapStore = defineStore(StoreName, () => {
         getCell,
         getCellByIndex,
         setTileSprite,
+        fillTileSpriteRange,
         clearTileSprite,
+        clearTileSpriteRange,
     };
 
 }, {

--- a/src/state/mapStore.ts
+++ b/src/state/mapStore.ts
@@ -4,7 +4,7 @@ import { computed, ref, reactive, watch, toRaw } from 'vue'
 
 const StoreName = "levelMap";
 
-export enum MAP_MODE {SELECT = 0, PAINT = 1, ERASE = 2};
+export enum MAP_MODE {SELECT = 0, PAINT = 1, SAMPLE = 2, ERASE = 3};
 
 type mapCell = {
     sprite: [number, number] | null;
@@ -85,7 +85,13 @@ export const useMapStore = defineStore(StoreName, () => {
     const editMode = ref<MAP_MODE>(MAP_MODE.SELECT);
 
     // Watchers
-    
+
+    watch(editMode, (newMode) => {
+        if (newMode !== MAP_MODE.SELECT) {
+            clearSelectionRange();
+        }
+    });
+
     watch(mapWidth, (newWidth, oldWidth) => {
         if (newWidth > oldWidth) {
             const diff = newWidth - oldWidth;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+
+export type cellPos = {row: number, col: number};


### PR DESCRIPTION
Adds several workflows for editing the game map.
1. Selection tool with sprite fill and clear options.
2. Brush tool for painting cells with sprites
3. Eyedropper for selecting sprites directly from the map grid
4. Eraser tool for bush based sprite clearing.

Also adds hot key functionality via vueuse for the map editing tools.
