### PR TITLE
Add output configuration options

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     CodeOutputPhaser: typeof import('./components/Output/CodeOutputPhaser.vue')['default']
     DisplaySettingsMenu: typeof import('./components/DisplaySettingsMenu.vue')['default']
     EditorToolbar: typeof import('./components/EditorToolbar.vue')['default']
+    KaplayExportOptions: typeof import('./components/Output/KaplayExportOptions.vue')['default']
     MapGrid: typeof import('./components/Map/MapGrid.vue')['default']
     MapGridCell: typeof import('./components/Map/MapGridCell.vue')['default']
     MapGridPane: typeof import('./components/Map/MapGridPane.vue')['default']

--- a/src/components/Output/CodeOutputKaplay.vue
+++ b/src/components/Output/CodeOutputKaplay.vue
@@ -11,31 +11,41 @@
 
 
 <script lang="ts" setup>
-    import { ref, watch } from 'vue';
+    import { computed, ref, watch } from 'vue';
     import VCodeBlock from '@wdns/vue-code-block';
     import { useMapStore } from '@/state/mapStore';
     import { useSpritesStore } from '@/state/spritesStore';
-    import { CODE_PREFIX_COMMENT, ADD_LEVEL_CODE, formatLevelConfig, formatLevelMap, formatSpriteAtlasConfig, 
-        parseMapGridForExport, parseSpriteSheetsForExport } from '@/util/kaplayJsExporters';
+    import { CODE_PREFIX_COMMENT, formatLevelConfig, formatLevelMap, formatSpriteAtlasConfig, formatAddLevelConfig,
+        parseMapGridForExport, parseSpriteSheetsForExport, type kaplayExportOptions} from '@/util/kaplayJsExporters';
+    import { useAppStore } from '@/state/appStore';
 
     const mapStore = useMapStore();
     const spritesStore = useSpritesStore();
+    const configStore = useAppStore();
     const code = ref<string>("");
+
+    const kaplayOptions = computed<kaplayExportOptions >(() => {
+        return {
+            outputSpritePath: configStore.outputSpritePath,
+            kaplayOptPrefix: configStore.kaplayOptPrefix
+        };
+    })
 
 
     const processMapData = () => {
         let mapExportData = parseMapGridForExport(mapStore.mapGrid, mapStore.mapWidth, mapStore.mapHeight);
         let spriteExportData = parseSpriteSheetsForExport(spritesStore.spriteSheets, mapExportData.spriteMapKeys);
 
-        let atlasConfigString = formatSpriteAtlasConfig(spriteExportData);
+        let atlasConfigString = formatSpriteAtlasConfig(spriteExportData, kaplayOptions.value);
         let asciMapString = formatLevelMap(mapExportData.asciMap);
-        let levelConfigString = formatLevelConfig(mapExportData.spriteMapKeys, spritesStore.spriteSheets);
-        code.value = CODE_PREFIX_COMMENT + atlasConfigString + asciMapString + levelConfigString + ADD_LEVEL_CODE;
+        let levelConfigString = formatLevelConfig(mapExportData.spriteMapKeys, spritesStore.spriteSheets, kaplayOptions.value);
+        let addLevelString = formatAddLevelConfig(kaplayOptions.value);
+        code.value = CODE_PREFIX_COMMENT + atlasConfigString + asciMapString + levelConfigString + addLevelString;
     }
 
     // Because of the hacky way we are hydrating the map from local storage
     // there might be the need to watch for the mapGrid to be updated on a fresh page load
-    watch([mapStore.mapGrid, spritesStore.spriteSheets], () => {
+    watch([mapStore.mapGrid, spritesStore.spriteSheets, kaplayOptions], () => {
         processMapData();
     });
 

--- a/src/components/Output/KaplayExportOptions.vue
+++ b/src/components/Output/KaplayExportOptions.vue
@@ -1,0 +1,25 @@
+<template>
+    <v-list>
+        <v-list-item title="" subtitle="Kaplay Options"></v-list-item>
+        <div class="px-4">
+            <v-text-field
+                v-model="appConfigStore.outputSpritePath" 
+                label="Sprite Path"
+                placeholder="sprites/">
+            </v-text-field>
+            <v-text-field
+                v-model="appConfigStore.kaplayOptPrefix" 
+                label="Method Prefix"
+                placeholder="kaplay">
+            </v-text-field>
+        </div>
+    </v-list>
+</template>
+
+<script lang="ts" setup>
+    import { useAppStore } from '@/state/appStore';
+
+
+    const appConfigStore = useAppStore();
+
+</script>

--- a/src/pages/output.vue
+++ b/src/pages/output.vue
@@ -36,15 +36,24 @@
             <v-tab value="kaplay">Kaplay.JS</v-tab>
             <v-tab value="phaser">Phaser.JS</v-tab>
         </v-tabs>
-        
+         <v-tabs-window v-model="tab">
+            <v-tabs-window-item value="kaplay">
+                <kaplay-export-options />
+            </v-tabs-window-item>
+            <v-tabs-window-item value="phaser">
+                <div></div>
+            </v-tabs-window-item>
+        </v-tabs-window>
       </v-navigation-drawer>
 
   </v-app>
 </template>
 
 <script lang="ts" setup>
-  import { ref } from 'vue'
-  const tab = ref('kaplay')
+    import { ref } from 'vue'
+    import KaplayExportOptions from '@/components/Output/KaplayExportOptions.vue';
+    
+    const tab = ref('kaplay')
 </script>
 
 <style lang="css">

--- a/src/state/appStore.ts
+++ b/src/state/appStore.ts
@@ -1,0 +1,19 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+
+const StoreName = "appConfig";
+
+export const useAppStore = defineStore(StoreName, () => {
+
+    const outputSpritePath = ref<string>("");
+    const kaplayOptPrefix = ref<string>("");
+
+    return {
+        outputSpritePath,
+        kaplayOptPrefix
+    };
+
+}, {
+    persist: true
+});

--- a/src/util/exportUtils.ts
+++ b/src/util/exportUtils.ts
@@ -1,0 +1,4 @@
+
+export const prefixMethodName = (methodName:string, prefix = "") : string => {
+    return prefix.length ? `${prefix}.${methodName}` : methodName;
+}

--- a/src/util/kaplayJsExporters.ts
+++ b/src/util/kaplayJsExporters.ts
@@ -1,9 +1,14 @@
 import type { kaplaySpriteAtlasConfig, mapCell, spriteSheet } from "@/types";
 import { MAP_SPRITE_IDS } from "@/config";
+import { prefixMethodName } from "./exportUtils";
+
+export interface kaplayExportOptions {
+    outputSpritePath: string,
+    kaplayOptPrefix: string
+}
 
 // TODO: Localize and Expand on the code commenting
 export const CODE_PREFIX_COMMENT = `// Level Definition and Config for use in the KaplayJS game framework \n`;
-export const ADD_LEVEL_CODE = `addLevel(levelMap, levelConfig);\n\n`
 
 export const parseMapGridForExport = (mapGrid: mapCell[][], mapWidth: number, mapHeight: number) => {
     const usedSpriteKeys = new Array<string>();
@@ -70,13 +75,13 @@ export const parseSpriteSheetsForExport = (spriteSheets: spriteSheet[], spriteMa
 };
 
 
-export const formatSpriteAtlasConfig = (config: Record<string, kaplaySpriteAtlasConfig>) :string => {
+export const formatSpriteAtlasConfig = (config: Record<string, kaplaySpriteAtlasConfig>, options: kaplayExportOptions) :string => {
     let output = '';
 
     Object.keys(config).forEach(key => {
         const sheetConfig = config[key];
 
-        output += `loadSpriteAtlas("${sheetConfig.imageURL}", {\n`;
+        output += `${prefixMethodName('loadSpriteAtlas', options.kaplayOptPrefix)}("${options.outputSpritePath}${sheetConfig.imageURL}", {\n`;
         sheetConfig.sprites.forEach(sprite => {
             output +=  `    ${sprite.name}: {\n`+
                        `      x: ${sprite.x},\n`+
@@ -102,16 +107,15 @@ export const formatLevelMap = (asciMap: string[]) :string => {
     return output;
 }
 
-export const formatLevelConfig = (spriteMapKeys: Record<string, [number, number]>, spriteSheets: spriteSheet[]): string => {
+export const formatLevelConfig = (spriteMapKeys: Record<string, [number, number]>, spriteSheets: spriteSheet[], options:kaplayExportOptions): string => {
 
     const formatConfigSprite = (asciKey:string, name: string, collisions = false, solid = false, tags: string[] = []) => {
 
         let spriteOutput = `        "${asciKey}": () => [\n` +
-                           `            sprite("${name}"),\n` +
-                           `            origin("bot"),\n`;
+                           `            ${prefixMethodName('sprite', options.kaplayOptPrefix)}("${name}"),\n`;
 
-        if (collisions) spriteOutput += `            area(),\n`;
-        if (solid) spriteOutput += `            body(),\n`;
+        if (collisions) spriteOutput += `            ${prefixMethodName('area', options.kaplayOptPrefix)}(),\n`;
+        if (solid) spriteOutput += `            ${prefixMethodName('body', options.kaplayOptPrefix)}(),\n`;
         
         tags.forEach(tag => {
             spriteOutput += `            "${tag}",\n`;
@@ -138,3 +142,8 @@ export const formatLevelConfig = (spriteMapKeys: Record<string, [number, number]
 
     return output;
 };
+
+export const formatAddLevelConfig = (options: kaplayExportOptions) => {
+    return `${prefixMethodName('addLevel', options.kaplayOptPrefix)}(levelMap, levelConfig);\n\n`
+};
+


### PR DESCRIPTION
Adds a new app wide configuration store.
Adds in configuration options for output including method prefixing and sprite paths.