### PR TITLE
Add base grid size config

### DIFF
--- a/src/components/Output/CodeOutputKaplay.vue
+++ b/src/components/Output/CodeOutputKaplay.vue
@@ -26,11 +26,11 @@
 
     const kaplayOptions = computed<kaplayExportOptions >(() => {
         return {
+            baseTileSize: mapStore.cellSize,
             outputSpritePath: configStore.outputSpritePath,
             kaplayOptPrefix: configStore.kaplayOptPrefix
         };
     })
-
 
     const processMapData = () => {
         let mapExportData = parseMapGridForExport(mapStore.mapGrid, mapStore.mapWidth, mapStore.mapHeight);

--- a/src/components/SettingsToolbar.vue
+++ b/src/components/SettingsToolbar.vue
@@ -1,9 +1,9 @@
 <template>
         <v-expansion-panels>
             <v-expansion-panel>
-                <v-expansion-panel-title>Map Display Settings</v-expansion-panel-title>
+                <v-expansion-panel-title>Map Configuration</v-expansion-panel-title>
                 <v-expansion-panel-text>
-                    <v-list>
+                    <v-list class="panel-list" density="compact">
                         <v-list-item>
                             <v-slider
                                 v-model="appConfigStore.mapScale"
@@ -25,13 +25,22 @@
                         <v-list-item>
                             <v-text-field
                                 v-model="appConfigStore.mapBackgroundColor"
-                                label="Background Color">
+                                label="Background Color"
+                                density="compact">
                             </v-text-field>
                         </v-list-item>
                         <v-list-item>
                             <v-text-field
                                 v-model="appConfigStore.gridLineColor"
-                                label="Grid Line Color">
+                                label="Grid Line Color"
+                                density="compact">
+                            </v-text-field>
+                        </v-list-item>
+                        <v-list-item>
+                            <v-text-field
+                                v-model="mapStore.cellSize"
+                                label="Base Cell Size"
+                                density="compact">
                             </v-text-field>
                         </v-list-item>
                     </v-list>
@@ -43,10 +52,18 @@
 <script lang="ts" setup>
     import { ref } from 'vue';
     import { useAppStore } from '@/state/appStore';
+    import { useMapStore } from '@/state/mapStore';
 
     const appConfigStore = useAppStore();
+    const mapStore = useMapStore();
 
     const minScale = ref(0.1);
     const maxScale = ref(2);
 
 </script>
+
+<style lang="css" scoped>
+    .v-list-item--density-compact:not(.v-list-item--nav).v-list-item--one-line {
+        padding-inline: 0;
+    }
+</style>

--- a/src/util/kaplayJsExporters.ts
+++ b/src/util/kaplayJsExporters.ts
@@ -3,6 +3,7 @@ import { MAP_SPRITE_IDS } from "@/config";
 import { prefixMethodName } from "./exportUtils";
 
 export interface kaplayExportOptions {
+    baseTileSize: number,
     outputSpritePath: string,
     kaplayOptPrefix: string
 }
@@ -126,8 +127,8 @@ export const formatLevelConfig = (spriteMapKeys: Record<string, [number, number]
     }
 
     let output = `const levelConfig = {\n` + 
-                 `    tileWidth: 32,\n` +
-                 `    tileHeight: 32,\n` + 
+                 `    tileWidth: ${options.baseTileSize},\n` +
+                 `    tileHeight: ${options.baseTileSize},\n` + 
                  `    tiles: {\n`;
     
     Object.keys(spriteMapKeys).forEach(key => {


### PR DESCRIPTION
Exposes the map grid cell size in the map configuration. Also wires it up properly for the code export/generation step.