### PR TITLE
Relocate and debounce map size controls

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     MapGridPhysicsCell: typeof import('./components/Map/MapGridPhysicsCell.vue')['default']
     MapGuides: typeof import('./components/Map/MapGuides.vue')['default']
     MapModeSelector: typeof import('./components/Map/MapModeSelector.vue')['default']
+    MapSizeControls: typeof import('./components/Map/MapSizeControls.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SettingsToolbar: typeof import('./components/SettingsToolbar.vue')['default']

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -1,15 +1,9 @@
 <template>
     <sprite-sheet-ingest-form />
-    <v-toolbar border density="compact" class="flex-0-0">
+    <v-toolbar border class="flex-0-0">
         <template v-slot:default>
             <div class="toolbar-contents">
-                <map-mode-selector></map-mode-selector>
-                <form class="map-size-controls">
-                    <span>{{ $t('tools.mapSizeLabel') }} </span>
-                    <input name="grid-width" type="number" v-model="mapStore.mapWidth" /> 
-                    <span>{{ $t('tools.mapSizeDimensionsSeparator') }}</span> 
-                    <input  name="grid-height" type="number" v-model="mapStore.mapHeight" />
-                </form>
+                <map-mode-selector />
             </div>
         </template>
         <template v-slot:append>
@@ -22,10 +16,7 @@
 </template>
 
 <script setup lang="ts">
-    import { useMapStore } from '@/state/mapStore';
     import { useAppStore } from '@/state/appStore';
-
-    const mapStore = useMapStore();
     const { openIngestForm } = useAppStore();
 </script>
 

--- a/src/components/Map/MapSizeControls.vue
+++ b/src/components/Map/MapSizeControls.vue
@@ -1,0 +1,57 @@
+<template>
+    <form class="map-size-controls">
+        <v-number-input
+            :label="$t('settings.mapWidth')"
+            controlVariant="stacked"
+            v-model="debouncedWidth"
+            :hide-details="true"
+            density="compact"
+            @update:model-value="debouncedWidthChange"
+            ></v-number-input>
+
+        <v-number-input
+            :label="$t('settings.mapHeight')"
+            controlVariant="stacked"
+            v-model="debouncedHeight"
+            :hide-details="true"
+            density="compact"
+            @update:model-value="debouncedHeightChange"
+            ></v-number-input>
+    </form>
+</template>
+
+<script setup lang="ts">
+    import { ref } from 'vue';
+    import { useDebounceFn } from '@vueuse/core'
+    import { useMapStore } from '@/state/mapStore';
+    
+    const mapStore = useMapStore();
+
+    const debouncedWidth = ref<number>(mapStore.mapWidth);
+    const debouncedHeight = ref<number>(mapStore.mapHeight);
+    const debounceTime = 500;
+
+    mapStore.$subscribe((_mutation, state) => {
+        debouncedWidth.value = state.mapWidth;
+        debouncedHeight.value = state.mapHeight;
+    });
+
+    const debouncedWidthChange = useDebounceFn((newWidth) => {
+        mapStore.mapWidth = newWidth;
+    }, debounceTime);
+
+    const debouncedHeightChange = useDebounceFn((newHeight) => {
+        mapStore.mapHeight = newHeight;
+    }, debounceTime);
+
+</script>
+
+<style>
+    .map-size-controls {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+        margin-bottom: 1rem;
+    }
+</style>

--- a/src/components/SettingsToolbar.vue
+++ b/src/components/SettingsToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-        <v-expansion-panels>
+        <v-expansion-panels :multiple="true">
             <v-expansion-panel>
                 <v-expansion-panel-title>{{ $t('settings.layers') }}</v-expansion-panel-title>
                 <v-expansion-panel-text class="layer-list">
@@ -10,6 +10,9 @@
                 <v-expansion-panel-title>{{ $t('settings.mapConfig') }}</v-expansion-panel-title>
                 <v-expansion-panel-text>
                     <v-list class="panel-list" density="compact">
+                        <v-list-item>
+                            <map-size-controls />
+                        </v-list-item>
                         <v-list-item>
                             <v-slider
                                 v-model="appConfigStore.mapScale"

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -44,6 +44,8 @@ const i18n = createI18n({
         spritePath: 'Sprite Path',
         methodPrefix: 'Method Prefix',
         kaplayMethodPlaceholder: 'kaplay',
+        mapWidth: 'Map Width',
+        mapHeight: 'Map Height',
       },
       tools: {
         selectModeToolTip: 'Select (s)',


### PR DESCRIPTION
The map size inputs aren't used often enough to require the prominent location, so relocating them to the settings pane.
Additionally the inputs need to be debounced so that they don't immediately resize the map to very small size whilst typing out the number, and thus losing map data.